### PR TITLE
Remove CI badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![](../../actions/workflows/cpp_cmake.yml/badge.svg)](../../actions)
-
 # ZTGK
 
 Video game project from team Linux Haters being made to present at ZTGK.


### PR DESCRIPTION
The CI badge has been removed from the README.md file. Since this file is usually the first point of contact for many users and developers, it is essential to keep its information up-to-date and clear. The badge was deemed unnecessary and hence has been removed.