### PR TITLE
Update asset name in GitHub workflow

### DIFF
--- a/.github/workflows/cpp_cmake.yml
+++ b/.github/workflows/cpp_cmake.yml
@@ -59,5 +59,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ${{github.workspace}}/build/Debug.zip
-          asset_name: build-artifacts
+          asset_name: Debug-build.zip
           asset_content_type: application/zip


### PR DESCRIPTION
Updated the asset name in the GitHub workflow configuration from 'build-artifacts' to 'Debug-build.zip'. This change introduces the use of a single zip file, which simplifies the handling of the build artifacts.