### PR TITLE
Add PBRPrimitives class and improve texture loading

### DIFF
--- a/src/ECS/Render/ModelLoading/Mesh.cpp
+++ b/src/ECS/Render/ModelLoading/Mesh.cpp
@@ -55,7 +55,7 @@ void Mesh::setupMesh() {
     // vertex Positions
     glEnableVertexAttribArray(0);
     glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *) 0);
-    // vertex normals
+    // vertex normals 
     glEnableVertexAttribArray(1);
     glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, sizeof(Vertex), (void *) offsetof(Vertex, Normal));
     // vertex texture coords

--- a/src/ECS/Render/Primitives/PBRPrimitives.cpp
+++ b/src/ECS/Render/Primitives/PBRPrimitives.cpp
@@ -1,0 +1,101 @@
+//
+// Created by redkc on 21/03/2024.
+//
+
+#include "PBRPrimitives.h"
+
+void PBRPrimitives::renderCube() {
+
+    glBindVertexArray(cubeVAO);
+    glDrawElements(GL_TRIANGLES, 36, GL_UNSIGNED_INT, 0);
+    glBindVertexArray(0);
+}
+
+void PBRPrimitives::renderQuad() {
+    glBindVertexArray(quadVAO);
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+    glBindVertexArray(0);
+}
+
+PBRPrimitives::PBRPrimitives() {
+  
+}
+
+void PBRPrimitives::Init() {
+    float cubeVertices[] = {
+            // positions      // normals        // texture coords
+            -1.0f, -1.0f, -1.0f,  0.0f,  0.0f,  1.0f,  0.0f,  0.0f,
+            1.0f, -1.0f, -1.0f,  0.0f,  0.0f,  1.0f,  1.0f,  0.0f,
+            1.0f,  1.0f, -1.0f,  0.0f,  0.0f,  1.0f,  1.0f,  1.0f,
+            -1.0f,  1.0f, -1.0f,  0.0f,  0.0f,  1.0f,  0.0f,  1.0f,
+            -1.0f, -1.0f,  1.0f,  0.0f,  0.0f,  1.0f,  0.0f,  0.0f,
+            1.0f, -1.0f,  1.0f,  0.0f,  0.0f,  1.0f,  1.0f,  0.0f,
+            1.0f,  1.0f,  1.0f,  0.0f,  0.0f,  1.0f,  1.0f,  1.0f,
+            -1.0f,  1.0f,  1.0f,  0.0f,  0.0f,  1.0f,  0.0f,  1.0f,
+    };
+
+    unsigned int cubeIndices[] = {
+            0, 1, 2, 2, 3, 0,   // back face
+            4, 5, 6, 6, 7, 4,   // front face
+            3, 2, 6, 6, 7, 3,   // top face
+            0, 1, 5, 5, 4, 0,   // bottom face
+            0, 3, 7, 7, 4, 0,   // left face
+            1, 2, 6, 6, 5, 1    // right face
+    };
+
+    glGenVertexArrays(1, &cubeVAO);
+    glGenBuffers(1, &cubeVBO);
+    glGenBuffers(1, &cubeEBO);
+
+    glBindVertexArray(cubeVAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, cubeVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(cubeVertices), cubeVertices, GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, cubeEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(cubeIndices), cubeIndices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0); // Position
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(3 * sizeof(float))); // Normals
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float))); // Texture Coords
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+
+    float quadVertices[] = {
+            // positions      // normals        // texture coords
+            -1.0f,  1.0f, 0.0f,   0.0f,  0.0f,  1.0f,  0.0f,  1.0f,
+            -1.0f, -1.0f, 0.0f,   0.0f,  0.0f,  1.0f,  0.0f,  0.0f,
+            1.0f,  1.0f, 0.0f,   0.0f,  0.0f,  1.0f,  1.0f,  1.0f,
+            1.0f, -1.0f, 0.0f,   0.0f,  0.0f,  1.0f,  1.0f,  0.0f,
+    };
+
+    unsigned int quadIndices[] = {
+            0, 1, 2,   // First Triangle
+            1, 2, 3    // Second Triangle
+    };
+
+
+    glGenVertexArrays(1, &quadVAO);
+    glGenBuffers(1, &quadVBO);
+    glGenBuffers(1, &quadEBO);
+
+    glBindVertexArray(quadVAO);
+
+    glBindBuffer(GL_ARRAY_BUFFER, quadVBO);
+    glBufferData(GL_ARRAY_BUFFER, sizeof(quadVertices), &quadVertices, GL_STATIC_DRAW);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, quadEBO);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(quadIndices), quadIndices, GL_STATIC_DRAW);
+
+    glEnableVertexAttribArray(0);
+    glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)0); // Position
+    glEnableVertexAttribArray(1);
+    glVertexAttribPointer(1, 3, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(3 * sizeof(float))); // Normals
+    glEnableVertexAttribArray(2);
+    glVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, 8 * sizeof(float), (void*)(6 * sizeof(float))); // Texture Coords
+    glBindBuffer(GL_ARRAY_BUFFER, 0);
+    glBindVertexArray(0);
+}

--- a/src/ECS/Render/Primitives/PBRPrimitives.h
+++ b/src/ECS/Render/Primitives/PBRPrimitives.h
@@ -1,0 +1,29 @@
+//
+// Created by redkc on 21/03/2024.
+//
+
+#ifndef ZTGK_PBRPRIMITIVES_H
+#define ZTGK_PBRPRIMITIVES_H
+
+#include "ECS/Render/Camera/Camera.h"
+
+class PBRPrimitives {
+public:
+    GLuint cubeVAO, cubeVBO, cubeEBO;
+    GLuint quadVAO, quadVBO, quadEBO;
+
+     GLfloat cubeVertices[8*8];
+     GLuint cubeIndices[36];
+
+     GLfloat quadVertices[8*4];
+     GLuint quadIndices[6];
+
+
+    PBRPrimitives();
+    void Init();
+    void renderCube();
+    void renderQuad();
+};
+
+
+#endif //ZTGK_PBRPRIMITIVES_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,8 @@
 #include "ECS/Render/Pipelines/PBRPipeline.h"
 #include "ECS/Render/Postprocessing/BloomPostProcess.h"
 #include "ECS/Render/ModelLoading/Model.h"
-
+#include "ECS/Render/Primitives/PBRPrimitives.h"
+#include "ECS/Render/Primitives/Primitives.h"
 
 
 #pragma endregion Includes
@@ -113,6 +114,7 @@ float lastX = 0;
 float lastY = 0;
 
 Primitives primitives;
+PBRPrimitives PBRPrimitives;
 LightSystem lightSystem(&camera);
 PBRPipeline pbrSystem(&camera,&primitives);
 RenderSystem renderSystem;
@@ -277,6 +279,7 @@ bool init() {
 
 void init_systems() {
     primitives.Init();
+    PBRPrimitives.Init();
     pbrSystem.Init();
     bloomSystem.Init(camera.saved_display_w, camera.saved_display_h);
     scene.systemManager.addSystem(&lightSystem);
@@ -284,8 +287,8 @@ void init_systems() {
     Color myColor = {255, 32, 21, 0};  // This defines your color.
 
     Material whiteMaterial = Material(myColor);
-    cubeModel = new Model(primitives.cubeVAO, whiteMaterial,vector<GLuint>(primitives.cubeIndices,primitives.cubeIndices + 36));
-   quadModel = new Model(primitives.quadVAO,whiteMaterial,vector<GLuint>(primitives.quadIndices,primitives.quadIndices + 6));
+    cubeModel = new Model(PBRPrimitives.cubeVAO, whiteMaterial,vector<GLuint>(PBRPrimitives.cubeIndices,PBRPrimitives.cubeIndices + 36));
+   quadModel = new Model(PBRPrimitives.quadVAO,whiteMaterial,vector<GLuint>(PBRPrimitives.quadIndices,PBRPrimitives.quadIndices + 6));
 }
 
 void load_enteties() {


### PR DESCRIPTION
A new class, PBRPrimitives, has been added for rendering cube and quad primitives. The Model and Material classes are now using PBRPrimitives instead of the normal Primitives class. Moreover, improvements have been made to the loading process of materials' textures, including efficient handling of missing textures by assigning default color values.