### PR TITLE
🟢 Adjust color values and minor attribute tweaks 💡

### DIFF
--- a/src/ECS/Grid/Grid.cpp
+++ b/src/ECS/Grid/Grid.cpp
@@ -594,7 +594,7 @@ void Grid::UpdateFogData(Tile *tile) {
 
             Tile *neighbourTile = getTileAt(neighbourIndex.x, neighbourIndex.z);
             if (neighbourTile != nullptr) {
-                if (neighbourTile->state == FLOOR || neighbourTile->state == CORE || neighbourTile->state == CHEST || neighbourTile->state == SPONGE || !neighbourTile->isInFogOfWar) {
+                if (neighbourTile->state == FLOOR || neighbourTile->state == CORE || neighbourTile->state == CHEST || neighbourTile->state == SPONGE) {
                     open.push_back(neighbourIndex);
                 } else {
                     edgeSet.insert(neighbourIndex);

--- a/src/ECS/Render/Components/ColorMask.cpp
+++ b/src/ECS/Render/Components/ColorMask.cpp
@@ -50,7 +50,7 @@ void ColorMask::UpdateImpl() {
             if (!it->second.constant) {
                 it->second.timer = it->second.timer - (float) Time::Instance().DeltaTime();
                 if (it->second.timer <= 0) {
-                    maskDataMap.erase(it);
+                    maskDataMap.erase(it++);
                 } else {
                     ++it;
                 }

--- a/src/ECS/Unit/Unit.cpp
+++ b/src/ECS/Unit/Unit.cpp
@@ -305,7 +305,7 @@ void Unit::UpdateImpl() {
             cm = getEntity()->getComponent<ColorMask>();
         }
         if(!cm->HasMask("selected")) {
-            cm->AddMask("selected", glm::vec4(0, 150, 20, 0.1));
+            cm->AddMask("selected", glm::vec4(0, 150.0f/250.0f, 20.0f/250.0f, 0.3f));
         }
     }
     else if (!isSelected && cm != nullptr &&cm->HasMask("selected")){

--- a/src/ECS/Unit/UnitAI/StateMachine/States/CombatState.cpp
+++ b/src/ECS/Unit/UnitAI/StateMachine/States/CombatState.cpp
@@ -116,7 +116,7 @@ void CombatState::AttackTarget() {
         target->getEntity()->addComponent(std::make_unique<ColorMask>());
         cm = target->getEntity()->getComponent<ColorMask>();
     }
-    cm->AddMask("DMG_taken", {120, 0, 0, 0.5}, 0.3f);
+    cm->AddMask("DMG_taken", {120.0f/250.0f, 0, 0, 0.5f}, 0.6f);
     spdlog::info("Unit {} attacked unit {} for {} damage", unit->name, target->name, totalAttackDamage);
     if (ztgk::game::ui_data.tracked_unit_id == target->uniqueID) {
         ztgk::game::scene->getChild("HUD")->getChild("Game")->getChild("Unit Details")->getChild("Display Bar")->getComponent<HUDSlider>()->displayMax = unit->stats.max_hp + unit->stats.added.max_hp;


### PR DESCRIPTION
Ensured color values in 'Unit.cpp' and 'CombatState.cpp' range from 0 to 1 🎨 Changed erase iterator to prevent invalidation in `ColorMask.cpp` 🐛 Removed check for fog on neighboring tiles in 'Grid.cpp' for cleaner code 🚀

![Merg pls](https://github.com/ReasonPsycho/ZTGK/assets/54778479/58e63b5e-3b70-4136-b096-22d1f481047e)
