### PR TITLE
🔄 Refactored collision system and improved performance 💡

### DIFF
--- a/src/ECS/Light/LightSystem.h
+++ b/src/ECS/Light/LightSystem.h
@@ -9,8 +9,10 @@
 #include "imgui.h"
 #include <ImGuizmo.h>
 #include "glad/glad.h"
+
 #include <vector>
 #include <memory>
+#include <algorithm>
 #include "glm/vec4.hpp"
 #include "Components/ILight.h"
 #include "Components/DirLight.h"
@@ -19,7 +21,6 @@
 #include "../System.h"
 #include "../Component.h"
 #include "ECS/Scene.h"
-#include <algorithm>
 
 
 class LightSystem : public System {

--- a/src/ECS/Raycasting/Colliders/BoxCollider.cpp
+++ b/src/ECS/Raycasting/Colliders/BoxCollider.cpp
@@ -42,7 +42,7 @@ void BoxCollider::UpdateImpl() {
     glm::mat4 scale = glm::scale(glm::mat4(1.0f), size);
     glm::mat4 translation = glm::translate(glm::mat4(1.0f), center);
     boxColliderData = BoxColliderData(translation * scale,boxColliderData.color);
-      
+    setIsDirty(false);
 }
 
 bool BoxCollider::intersects(glm::vec3 p1, glm::vec3 p2, glm::vec3 p3, glm::vec3 p4) {

--- a/src/ECS/Raycasting/CollisionSystem.h
+++ b/src/ECS/Raycasting/CollisionSystem.h
@@ -10,6 +10,11 @@
 #include "ECS/Component.h"
 #include "ECS/Raycasting/Colliders/BoxCollider.h"
 #include "ECS/Raycasting/Colliders/SphereCollider.h"
+
+#include <vector>
+#include <memory>
+#include <algorithm>
+
 class Collider;
 class BoxCollider;
 class SphereCollider;
@@ -33,8 +38,8 @@ public:
 
     std::vector<Collider*> getCollidersInArea(glm::vec3 p1, glm::vec3 p2);
 
-    std::unordered_map<unsigned, std::vector<BoxCollider*>> BoxColliders;
-    std::unordered_map<unsigned, std::vector<SphereCollider*>> SphereColliders;
+   std::vector<BoxCollider*> BoxColliders;
+     std::vector<SphereCollider*> SphereColliders;
     
 
 private:


### PR DESCRIPTION
Made substantial changes to the collision system by replacing unordered maps with vectors. 🚀 This simplifies and improves the performance of the addComponent and removeComponent functions. Also, used dynamic_cast instead of static_cast for better type safety. 🛡 In `UpdateImpl`, used simple for loop instead of ranges version to iterate box and sphere colliders. 🔄 In BoxCollider, set isDirty to false after updating the boxColliderData. 👥

![Merg pls](https://github.com/ReasonPsycho/ZTGK/assets/54778479/58e63b5e-3b70-4136-b096-22d1f481047e)
