### PR TITLE
🔄 Update animation player and renderer components 🔄

### DIFF
--- a/src/ECS/Render/Components/AnimationPlayer.cpp
+++ b/src/ECS/Render/Components/AnimationPlayer.cpp
@@ -24,6 +24,7 @@ void AnimationPlayer::UpdateImpl() {
     } else{
         Render *render = getEntity()->getComponent<Render>();
         if (render != nullptr) {
+            render->animationTransforms = animator.GetFinalBoneMatrices();
             render->isAnimated = false;
         }
     }
@@ -58,6 +59,7 @@ void AnimationPlayer::PlayAnimation(std::string path, bool looping, float animat
 
 void AnimationPlayer::StopAnimation() {
     animator.m_CurrentTime = 0;
+    animator.UpdateAnimation(0);
     isPlaying = false;
     looping = false;
     animationSpeed = 1.0f;


### PR DESCRIPTION
This commit adds improvements to the animation player and rendering components within the ECS. It does this by ensuring that the final bone matrices are always updated in animation transforms, and updates the animation upon stopping it. These changes aim to enhance overall performance and correctness of animations.

![Merg pls](https://github.com/ReasonPsycho/ZTGK/assets/54778479/58e63b5e-3b70-4136-b096-22d1f481047e)
