### PR TITLE
🔄 Updated shader to use NonAnimatedLocalPos for noise calculation

### DIFF
--- a/res/shaders/phong.frag
+++ b/res/shaders/phong.frag
@@ -15,6 +15,7 @@ in VS_OUT {
     vec2 TexCoords;
     vec3 WorldPos;
     vec3 LocalPos;
+    vec3 NonAnimatedLocalPos;
     vec3 Normal;
     TangentData tangentData;
 }fs_in;
@@ -223,9 +224,9 @@ void main()
         if (texCoords.x > 1.0 || texCoords.y > 1.0 || texCoords.x < 0.0 || texCoords.y < 0.0)
         discard;
 
-        float dirtinessMap  =  1 *  cnoise(fs_in.LocalPos*2) +
-        +  0.5 * cnoise(fs_in.LocalPos*4) +
-        + 0.25 * cnoise(fs_in.LocalPos*8);
+        float dirtinessMap  =  1 *  cnoise(fs_in.NonAnimatedLocalPos*2) +
+        +  0.5 * cnoise(fs_in.NonAnimatedLocalPos*4) +
+        + 0.25 * cnoise(fs_in.NonAnimatedLocalPos*8);
         dirtinessMap = dirtinessMap / (1 + 0.5 + 0.25);
         dirtinessMap = pow(dirtinessMap, dirtLevel * 4);
         //dirtinessMap = (dirtinessMap + 1) * 0.5; // Scale the noise from -1.0 - 1.0 to 0.0 - 1.0

--- a/res/shaders/phong.vert
+++ b/res/shaders/phong.vert
@@ -30,6 +30,7 @@ out VS_OUT {
     vec2 TexCoords;
     vec3 WorldPos;
     vec3 LocalPos;
+    vec3 NonAnimatedLocalPos;
     vec3 Normal;
     TangentData tangentData;
 }vs_out;
@@ -59,6 +60,7 @@ void main()
     //Standard calculation
     vs_out.TexCoords = aTexCoords;
     vs_out.LocalPos = vec3(totalPosition);
+    vs_out.NonAnimatedLocalPos = aPos;
     vs_out.WorldPos = vec3(model* totalPosition);
     vs_out.Normal = mat3(transpose(inverse(model))) * aNormal;
     gl_Position = projection * view * vec4(vs_out.WorldPos, 1.0);


### PR DESCRIPTION
This commit introduces a `NonAnimatedLocalPos` vector in both the phong fragment and phong vertex shaders. The `NonAnimatedLocalPos` is now used instead of `LocalPos` in the phong fragment shader's noise calculation, which improves the quality of the generated noise. It ensures that noise map consistency is independent of the object's animation state. 💡💽

![Merg pls](https://github.com/ReasonPsycho/ZTGK/assets/54778479/58e63b5e-3b70-4136-b096-22d1f481047e)
