### PR TITLE
🔧 Adjust Phong pipeline gamma value 🖼️

### DIFF
--- a/src/ECS/Render/Pipelines/Phong/PhongPipeline.cpp
+++ b/src/ECS/Render/Pipelines/Phong/PhongPipeline.cpp
@@ -302,7 +302,7 @@ void PhongPipeline::WriteToBackBuffer(Camera *camera) {
     textureSampler.setVec3("outline_color",outline_color);  // Here 0 is the texture unit
 
     textureSampler.setFloat("exposure", exposure);  // Here 0 is the texture unit
-    textureSampler.setFloat("gamma", gamma);  // Here 0 is the texture unit
+    textureSampler.setFloat("gamma", 1.5f);  // Here 0 is the texture unit
     glBindFramebuffer(GL_FRAMEBUFFER, 0);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT); //Depends on your needs
     _primitives->renderQuad();


### PR DESCRIPTION
This commit updates the gamma value in the Phong pipeline from an adjustable variable to a fixed value of 1.5f 🔄. This change ensures consistent brightness and contrast across different rendering conditions, contributing to a better visual experience 🕶️.

![Merg pls](https://github.com/ReasonPsycho/ZTGK/assets/54778479/58e63b5e-3b70-4136-b096-22d1f481047e)
